### PR TITLE
Add Gherkin Test Cases for User Stories

### DIFF
--- a/test-cases/test_cases.md
+++ b/test-cases/test_cases.md
@@ -1,0 +1,49 @@
+# Test Cases in Gherkin Format
+
+## User Story 1: Setup ADO Test Plan to the Alita Agent
+
+### Test Case 1: Verify ADO Test Plan Setup
+```
+Feature: Setup ADO Test Plan to the Alita Agent
+
+  Scenario: Verify ADO Test Plan Setup
+    Given the ADO Test Plan is accessible
+    When the user sets up the ADO Test Plan to the Alita Agent
+    Then the ADO Test Plan should be successfully set up to the Alita Agent
+```
+
+## User Story 2: Create Datasource
+
+### Test Case 1: Verify Datasource Creation
+```
+Feature: Create Datasource
+
+  Scenario: Verify Datasource Creation
+    Given the user has access to the datasource creation page
+    When the user creates a new datasource
+    Then the datasource should be successfully created
+```
+
+## User Story 3: Pricing Management
+
+### Test Case 1: Verify Pricing Management Functionality
+```
+Feature: Pricing Management
+
+  Scenario: Verify Pricing Management Functionality
+    Given the user has access to the pricing management page
+    When the user manages the pricing
+    Then the pricing should be successfully managed
+```
+
+## User Story 4: Upload Pricing Files
+
+### Test Case 1: Verify Pricing Files Upload
+```
+Feature: Upload Pricing Files
+
+  Scenario: Verify Pricing Files Upload
+    Given the user has access to the pricing files upload page
+    When the user uploads the pricing files
+    Then the pricing files should be successfully uploaded
+```


### PR DESCRIPTION
Added test cases in Gherkin format for the following user stories:
1. Setup ADO Test Plan to the Alita Agent
2. Create Datasource
3. Pricing Management
4. Upload Pricing Files

The test cases are saved in the `test-cases/test_cases.md` file.